### PR TITLE
Added sample files for script output

### DIFF
--- a/samples/multiyear/COPYING.WTFNMFPLv1a.text
+++ b/samples/multiyear/COPYING.WTFNMFPLv1a.text
@@ -1,0 +1,23 @@
+Copyright (C) 2013-2016 Awesome Coder
+
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes:
+
+    DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+                    Version 1, October 2013
+
+ Copyright (C) 2013 Ben McGinnes <ben@adversary.org>
+
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+   DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+  1. Do not hold the author(s), creator(s), developer(s) or
+     distributor(s) liable for anything that happens or goes wrong
+     with your use of the work.

--- a/samples/multiyear/COPYING.WTFNMFPLv1a.txt
+++ b/samples/multiyear/COPYING.WTFNMFPLv1a.txt
@@ -1,0 +1,23 @@
+Copyright (C) Awesome Coder, 2013-2016
+
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes:
+
+    DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+                    Version 1, October 2013
+
+ Copyright (C) 2013 Ben McGinnes <ben@adversary.org>
+
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+   DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+  1. Do not hold the author(s), creator(s), developer(s) or
+     distributor(s) liable for anything that happens or goes wrong
+     with your use of the work.

--- a/samples/multiyear/COPYING.WTFNMFPLv1u.text
+++ b/samples/multiyear/COPYING.WTFNMFPLv1u.text
@@ -1,0 +1,23 @@
+Copyright © 2013-2016 Awesome Coder
+
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes:
+
+    DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+                    Version 1, October 2013
+
+ Copyright © 2013 Ben McGinnes <ben@adversary.org>
+
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+   DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+  1. Do not hold the author(s), creator(s), developer(s) or
+     distributor(s) liable for anything that happens or goes wrong
+     with your use of the work.

--- a/samples/multiyear/COPYING.WTFNMFPLv1u.txt
+++ b/samples/multiyear/COPYING.WTFNMFPLv1u.txt
@@ -1,0 +1,23 @@
+Copyright © Awesome Coder, 2013-2016
+
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes:
+
+    DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+                    Version 1, October 2013
+
+ Copyright © 2013 Ben McGinnes <ben@adversary.org>
+
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+   DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+  1. Do not hold the author(s), creator(s), developer(s) or
+     distributor(s) liable for anything that happens or goes wrong
+     with your use of the work.

--- a/samples/multiyear/ascii_boilerplate.text
+++ b/samples/multiyear/ascii_boilerplate.text
@@ -1,0 +1,6 @@
+Copyright (C) 2013-2016 Awesome Coder
+ 
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes.  See the
+COPYING.WTFNMFPLv1a.text file for more details.

--- a/samples/multiyear/ascii_boilerplate.txt
+++ b/samples/multiyear/ascii_boilerplate.txt
@@ -1,0 +1,6 @@
+Copyright (C) Awesome Coder, 2013-2016
+ 
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes.  See the
+COPYING.WTFNMFPLv1a.txt file for more details.

--- a/samples/multiyear/utf8_boilerplate.text
+++ b/samples/multiyear/utf8_boilerplate.text
@@ -1,0 +1,6 @@
+Copyright © 2013-2016 Awesome Coder
+ 
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes.  See the
+COPYING.WTFNMFPLv1u.text file for more details.

--- a/samples/multiyear/utf8_boilerplate.txt
+++ b/samples/multiyear/utf8_boilerplate.txt
@@ -1,0 +1,6 @@
+Copyright © Awesome Coder, 2013-2016
+ 
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes.  See the
+COPYING.WTFNMFPLv1u.txt file for more details.

--- a/samples/singleyear/COPYING.WTFNMFPLv1a.text
+++ b/samples/singleyear/COPYING.WTFNMFPLv1a.text
@@ -1,0 +1,23 @@
+Copyright (C) 2016 Awesome Coder
+
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes:
+
+    DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+                    Version 1, October 2013
+
+ Copyright (C) 2013 Ben McGinnes <ben@adversary.org>
+
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+   DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+  1. Do not hold the author(s), creator(s), developer(s) or
+     distributor(s) liable for anything that happens or goes wrong
+     with your use of the work.

--- a/samples/singleyear/COPYING.WTFNMFPLv1a.txt
+++ b/samples/singleyear/COPYING.WTFNMFPLv1a.txt
@@ -1,0 +1,23 @@
+Copyright (C) Awesome Coder, 2016
+
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes:
+
+    DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+                    Version 1, October 2013
+
+ Copyright (C) 2013 Ben McGinnes <ben@adversary.org>
+
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+   DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+  1. Do not hold the author(s), creator(s), developer(s) or
+     distributor(s) liable for anything that happens or goes wrong
+     with your use of the work.

--- a/samples/singleyear/COPYING.WTFNMFPLv1u.text
+++ b/samples/singleyear/COPYING.WTFNMFPLv1u.text
@@ -1,0 +1,23 @@
+Copyright © 2016 Awesome Coder
+
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes:
+
+    DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+                    Version 1, October 2013
+
+ Copyright © 2013 Ben McGinnes <ben@adversary.org>
+
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+   DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+  1. Do not hold the author(s), creator(s), developer(s) or
+     distributor(s) liable for anything that happens or goes wrong
+     with your use of the work.

--- a/samples/singleyear/COPYING.WTFNMFPLv1u.txt
+++ b/samples/singleyear/COPYING.WTFNMFPLv1u.txt
@@ -1,0 +1,23 @@
+Copyright © Awesome Coder, 2016
+
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes:
+
+    DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+                    Version 1, October 2013
+
+ Copyright © 2013 Ben McGinnes <ben@adversary.org>
+
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+   DO WHAT THE FUCK YOU WANT TO BUT IT'S NOT MY FAULT PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+  1. Do not hold the author(s), creator(s), developer(s) or
+     distributor(s) liable for anything that happens or goes wrong
+     with your use of the work.

--- a/samples/singleyear/ascii_boilerplate.text
+++ b/samples/singleyear/ascii_boilerplate.text
@@ -1,0 +1,6 @@
+Copyright (C) 2016 Awesome Coder
+ 
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes.  See the
+COPYING.WTFNMFPLv1a.text file for more details.

--- a/samples/singleyear/ascii_boilerplate.txt
+++ b/samples/singleyear/ascii_boilerplate.txt
@@ -1,0 +1,6 @@
+Copyright (C) Awesome Coder, 2016
+ 
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes.  See the
+COPYING.WTFNMFPLv1a.txt file for more details.

--- a/samples/singleyear/utf8_boilerplate.text
+++ b/samples/singleyear/utf8_boilerplate.text
@@ -1,0 +1,6 @@
+Copyright © 2016 Awesome Coder
+ 
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes.  See the
+COPYING.WTFNMFPLv1u.text file for more details.

--- a/samples/singleyear/utf8_boilerplate.txt
+++ b/samples/singleyear/utf8_boilerplate.txt
@@ -1,0 +1,6 @@
+Copyright © Awesome Coder, 2016
+ 
+This work is free.  You can redistribute it and/or modify it under the
+terms of the Do What The Fuck You Want To But It's Not My Fault Public
+License, Version 1, as published by Ben McGinnes.  See the
+COPYING.WTFNMFPLv1u.txt file for more details.


### PR DESCRIPTION
- For those (hopefully rare) cases where Python 2.7 or higher isn't
  available.
- Subdirectories of the samples/ dir should be self-explanatory.
- People modifying the singleyear versions will need to change 2016 to
  whatever year it is.
- People modifying the multi-user version will need to change 2013 to
  their first specified year and 2016 to their last.
- The name needs to be changed from the (gender neutral) "Awesome
  Coder" to whatever name you're blaming what you did on.  ;)

This should address the laziest issue tracking on github for this
thing's issue #3.
